### PR TITLE
app.updateForecastCard() should be commented out

### DIFF
--- a/step-04/scripts/app.js
+++ b/step-04/scripts/app.js
@@ -175,6 +175,6 @@
     }
   };
   // Uncomment the line below to test with the provided fake data
-  app.updateForecastCard(fakeForecast);
+  // app.updateForecastCard(fakeForecast);
 
 })();


### PR DESCRIPTION
As detailed in the codelab text, this call should be commented by default.
Fixes #40
