### PR TITLE
fix to prevent descender being cut off

### DIFF
--- a/styles/inline.css
+++ b/styles/inline.css
@@ -356,7 +356,7 @@ body {
   font-size: 14px;
   font-weight: 500;
   text-transform: uppercase;
-  line-height: 1;
+  line-height: 2;
   letter-spacing: 0;
   overflow: hidden;
   will-change: box-shadow;


### PR DESCRIPTION
At line-height: 1; g in Progressive is cut off see [screenshot](https://www.dropbox.com/s/2yy5tqwq0o5qjgg/Screenshot%202016-08-08%2020.42.30.png?dl=0)
