### PR TITLE
Fix sunset label

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -92,7 +92,7 @@
             <span class="value"></span>
           </div>
           <div class="sunset">
-              <span class="label">Sunrise:</span>
+              <span class="label">Sunset:</span>
               <span class="value"></span>
             </div>
         </div>


### PR DESCRIPTION
The sunset display had a duplicate sunrise as its label.