### PR TITLE
fix: Add dotenv support for localhost

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "dotenv": "^8.0.0",
     "express": "^4.16.4",
     "express-http-to-https": "^1.1.4",
     "node-fetch": "^2.3.0"

--- a/server.js
+++ b/server.js
@@ -18,6 +18,7 @@
  */
 'use strict';
 
+require('dotenv').config();
 const express = require('express');
 const fetch = require('node-fetch');
 const redirectToHTTPS = require('express-http-to-https').redirectToHTTPS;
@@ -25,7 +26,6 @@ const redirectToHTTPS = require('express-http-to-https').redirectToHTTPS;
 // CODELAB: Change this to add a delay (ms) before the server responds.
 const FORECAST_DELAY = 0;
 
-// CODELAB: If running locally, set your Dark Sky API key here
 const API_KEY = process.env.DARKSKY_API_KEY;
 const BASE_URL = `https://api.darksky.net/forecast`;
 


### PR DESCRIPTION
Adds the dotenv package to create the same support for localhost running and for glitch, making the support consistent between both.