### PR TITLE
fix: cards never show up after they were removed once

### DIFF
--- a/public/scripts/app.js
+++ b/public/scripts/app.js
@@ -63,6 +63,7 @@ function removeLocation(evt) {
     delete weatherApp.selectedLocations[parent.id];
     saveLocationList(weatherApp.selectedLocations);
   }
+  parent.remove();
 }
 
 /**

--- a/public/scripts/app.js
+++ b/public/scripts/app.js
@@ -58,12 +58,11 @@ function addLocation() {
  */
 function removeLocation(evt) {
   const parent = evt.srcElement.parentElement;
-  parent.setAttribute('hidden', true);
+  parent.remove();
   if (weatherApp.selectedLocations[parent.id]) {
     delete weatherApp.selectedLocations[parent.id];
     saveLocationList(weatherApp.selectedLocations);
   }
-  parent.remove();
 }
 
 /**


### PR DESCRIPTION
Bug: If I remove the card of a certain location (eg. New York) and then add it again, it won't show up.
This is due to, the 'hidden' attribute. When I add the location again, the card remains 'hidden'.
I think, removing the DOM element is a clean and expected way to handle this.