### PR TITLE
use SPDX identifier for license

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "bugs": {
     "url": "https://github.com/googlecodelabs/your-first-pwapp/issues"
   },
-  "license": "Apache2",
+  "license": "APACHE-2",
   "keywords": [
     "progressive-web-app",
     "pwa",


### PR DESCRIPTION
Resolves

> warning package.json: License should be a valid SPDX license expression

**edit:** will sign the CLA another day,  no time to read it atm